### PR TITLE
Fix serverPort const usage

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,6 @@ app.get('/contact', (req, res) => {
   res.sendFile(path.join(__dirname + '/html/contact.html'));
 });
 
-app.listen(3000);
+app.listen(serverPort);
 
 console.log(`Server is up and running in ${serverUrl}${serverPort}`);


### PR DESCRIPTION
use of serverPort const in `app.listen` method to easy replace port number in one place if needed